### PR TITLE
Extracted common pattern from multiple functions that return bools.

### DIFF
--- a/dni/exceptions.py
+++ b/dni/exceptions.py
@@ -118,3 +118,9 @@ class MultipleMatchesException(Exception):
     """
     Expected only one occurrence, but found multiple.
     """
+
+
+class DoNotRaiseMe(Exception):
+    """
+    Never raise me!
+    """


### PR DESCRIPTION
A few functions in the codebase followed a pattern of:

- Run some code and return True if no exception
- If some exceptions, return False
- If some other exceptions, return True

But did it in a duplicate way. This refactor puts the common part in shared functions.

